### PR TITLE
pinecone 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "youtube-transcript": "^1.0.6"
             },
             "devDependencies": {
-                "@pinecone-database/pinecone": "^1.1.2",
+                "@pinecone-database/pinecone": "^2.0.1",
                 "@qdrant/js-client-rest": "^1.7.0",
                 "@tsconfig/recommended": "^1.0.3",
                 "@types/debug": "^4.1.12",
@@ -53,7 +53,7 @@
                 "node": ">= 18.0.0"
             },
             "peerDependencies": {
-                "@pinecone-database/pinecone": "^1.1.2",
+                "@pinecone-database/pinecone": "^2.0.0",
                 "@qdrant/js-client-rest": "^1.7.0",
                 "chromadb": "^1.7.3",
                 "cohere-ai": "^7.6.2",
@@ -1014,9 +1014,9 @@
             }
         },
         "node_modules/@pinecone-database/pinecone": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-1.1.3.tgz",
-            "integrity": "sha512-bGldvvoAr4agVZ2ql4RZesXIDjMLjnuqNmKYfMQoVO3UFRYeuO9z+1WJodvanGIPY2iGh1w9yz0jDAkBiT53qw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-2.0.1.tgz",
+            "integrity": "sha512-a1ejzrqdSQ2yW+9QUi2TVlKwYUbrvGH+QH6POJhITyaOz9ANE+EhXqToC9af93Ctzq9n87+bOUvBvewLeW++Mw==",
             "devOptional": true,
             "dependencies": {
                 "@sinclair/typebox": "^0.29.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "youtube-transcript": "^1.0.6"
     },
     "devDependencies": {
-        "@pinecone-database/pinecone": "^1.1.2",
+        "@pinecone-database/pinecone": "^2.0.1",
         "@qdrant/js-client-rest": "^1.7.0",
         "@tsconfig/recommended": "^1.0.3",
         "@types/debug": "^4.1.12",
@@ -89,7 +89,7 @@
         "weaviate-ts-client": "^2.0.0"
     },
     "peerDependencies": {
-        "@pinecone-database/pinecone": "^1.1.2",
+        "@pinecone-database/pinecone": "^2.0.0",
         "@qdrant/js-client-rest": "^1.7.0",
         "chromadb": "^1.7.3",
         "cohere-ai": "^7.6.2",
@@ -132,7 +132,7 @@
         "node": ">= 18.0.0"
     },
     "overrides": {
-        "@pinecone-database/pinecone": "^1.1.2",
+        "@pinecone-database/pinecone": "^2.0.0",
         "weaviate-ts-client": "^2.0.0",
         "hnswlib-node": "^2.1.0",
         "vectordb": "^0.4.6"

--- a/src/vectorDb/pinecone-db.ts
+++ b/src/vectorDb/pinecone-db.ts
@@ -15,21 +15,26 @@ export class PineconeDb implements BaseDb {
 
     constructor({ projectName, namespace }: { projectName: string; namespace: string }) {
         this.client = new Pinecone({
-            apiKey: process.env.PINECONE_API_KEY,
-            environment: process.env.PINECONE_ENVIRONMENT,
+            apiKey: process.env.PINECONE_API_KEY
         });
         this.projectName = projectName;
         this.namespace = namespace;
     }
 
     async init({ dimensions }: { dimensions: number }) {
-        const list = (await this.client.listIndexes()).map((i) => i.name);
+        const list = (await this.client.listIndexes()).indexes.map((i) => i.name);
         if (list.indexOf(this.projectName) > -1) return;
 
         await this.client.createIndex({
             name: this.projectName,
             dimension: dimensions,
             metric: 'cosine',
+            spec: {
+            serverless: {
+                cloud: 'aws',
+                region: 'us-west-2',
+                },
+            },
         });
     }
 


### PR DESCRIPTION
Fixes #5 

Todo before merging:
- [ ] Determine if the hardcoded values for `createIndex.spec` should be new env vars.
- [ ] Update readme to remove reference to `PINECONE_ENVIRONMENT`
