### PR TITLE
Enable usage of the local WeaviateDB without a secure connection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,7 +700,7 @@ npm install weaviate-ts-client
 ```TS
 import { WeaviateDb } from '@llm-tools/embedjs/vectorDb/weaviate';
 
-.setVectorDb(new WeaviateDb({ host: '...', apiKey: '...', className: '...' }))
+.setVectorDb(new WeaviateDb({ host: '...', apiKey: '...', className: '...', scheme: '...' }))
 ```
 
 ## Qdrant

--- a/src/vectorDb/weaviate-db.ts
+++ b/src/vectorDb/weaviate-db.ts
@@ -13,9 +13,9 @@ export class WeaviateDb implements BaseDb {
     private readonly className: string;
     private readonly client: WeaviateClient;
 
-    constructor({ host, apiKey, className }: { host: string; apiKey: string; className: string }) {
+    constructor({ host, apiKey, className, scheme = 'https' }: { host: string; apiKey: string; className: string; scheme: string }) {
         // @ts-ignore
-        this.client = weaviate.client({ scheme: 'https', host, apiKey: new ApiKey(apiKey) });
+        this.client = weaviate.client({ scheme, host, apiKey: new ApiKey(apiKey) });
         this.className = toTitleCase(className); // Weaviate translates the className during create to title case and errors at other places
     }
 

--- a/src/vectorDb/weaviate-db.ts
+++ b/src/vectorDb/weaviate-db.ts
@@ -13,7 +13,7 @@ export class WeaviateDb implements BaseDb {
     private readonly className: string;
     private readonly client: WeaviateClient;
 
-    constructor({ host, apiKey, className, scheme = 'https' }: { host: string; apiKey: string; className: string; scheme: string }) {
+    constructor({ host, apiKey, className, scheme = 'https' }: { host: string; apiKey: string; className: string; scheme: 'http' | 'https' }) {
         // @ts-ignore
         this.client = weaviate.client({ scheme, host, apiKey: new ApiKey(apiKey) });
         this.className = toTitleCase(className); // Weaviate translates the className during create to title case and errors at other places


### PR DESCRIPTION
The default connection will be https, but in constructor you can set it to be http. This is a good approach to having a vector database inside Docker. There is no need to set up certificates.