### PR TITLE
allow openai to use custom endpoints

### DIFF
--- a/src/embeddings/openai-3small-embeddings.ts
+++ b/src/embeddings/openai-3small-embeddings.ts
@@ -4,8 +4,8 @@ import { BaseEmbeddings } from '../interfaces/base-embeddings.js';
 export class OpenAi3SmallEmbeddings implements BaseEmbeddings {
     private model: OpenAIEmbeddings;
 
-    constructor() {
-        this.model = new OpenAIEmbeddings({ modelName: 'text-embedding-3-small', maxConcurrency: 3, maxRetries: 5 });
+    constructor({ configuration }: { configuration?: Object } = null) {
+        this.model = new OpenAIEmbeddings({ modelName: 'text-embedding-3-small', maxConcurrency: 3, maxRetries: 5, configuration: configuration });
     }
 
     getDimensions(): number {

--- a/src/models/openai-model.ts
+++ b/src/models/openai-model.ts
@@ -8,15 +8,17 @@ import { Chunk, ConversationHistory } from '../global/types.js';
 export class OpenAi extends BaseModel {
     private readonly debug = createDebugMessages('embedjs:model:OpenAi');
     private readonly modelName: string;
+    private readonly configuration: Object;
     private model: ChatOpenAI;
 
-    constructor({ temperature, modelName }: { temperature?: number; modelName: string }) {
+    constructor({ temperature, modelName, configuration }: { temperature?: number; modelName: string, configuration?: Object }) {
         super(temperature);
         this.modelName = modelName;
+        this.configuration = configuration;
     }
 
     override async init(): Promise<void> {
-        this.model = new ChatOpenAI({ temperature: this.temperature, model: this.modelName });
+        this.model = new ChatOpenAI({ temperature: this.temperature, model: this.modelName, configuration: this.configuration });
     }
 
     override async runQuery(


### PR DESCRIPTION
This pull request is a small edit to allow additional openai options to be customized, for example if you are hosting your local LLM in a external server and you are using openai API to request LLM. Base path must be customized in this case.