### PR TITLE
current query shouldn’t be part of the conversation history

### DIFF
--- a/src/interfaces/base-model.ts
+++ b/src/interfaces/base-model.ts
@@ -48,7 +48,7 @@ export abstract class BaseModel {
         });
 
         // Run LLM implementation in subclass
-        const response = await this.runQuery(system, userQuery, supportingContext, conversation.entries);
+        const response = await this.runQuery(system, userQuery, supportingContext, conversation.entries.slice(0, -1));
 
         const uniqueSources = this.extractUniqueSources(supportingContext);
         const newEntry: Message = {


### PR DESCRIPTION
it causes send duplicate conversation to models, which results in errors in Vertex