### PR TITLE
docs: fixes link to main npm package in READMEs

### DIFF
--- a/core/embedjs-interfaces/README.md
+++ b/core/embedjs-interfaces/README.md
@@ -1,7 +1,7 @@
 # embedjs-interfaces
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/core/embedjs-utils/README.md
+++ b/core/embedjs-utils/README.md
@@ -1,7 +1,7 @@
 # embedjs-utils
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-astra/README.md
+++ b/databases/embedjs-astra/README.md
@@ -1,7 +1,7 @@
-# embedjs-cosmos
+# embedjs-astra
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-cosmos/README.md
+++ b/databases/embedjs-cosmos/README.md
@@ -1,7 +1,7 @@
 # embedjs-cosmos
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-hnswlib/README.md
+++ b/databases/embedjs-hnswlib/README.md
@@ -1,7 +1,7 @@
 # embedjs-hnswlib
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-lancedb/README.md
+++ b/databases/embedjs-lancedb/README.md
@@ -1,7 +1,7 @@
 # embedjs-lancedb
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-lmdb/README.md
+++ b/databases/embedjs-lmdb/README.md
@@ -1,7 +1,7 @@
 # embedjs-lmdb
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-mongodb/README.md
+++ b/databases/embedjs-mongodb/README.md
@@ -1,7 +1,7 @@
 # embedjs-mongodb
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-pinecone/README.md
+++ b/databases/embedjs-pinecone/README.md
@@ -1,7 +1,7 @@
 # embedjs-pinecone
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-qdrant/README.md
+++ b/databases/embedjs-qdrant/README.md
@@ -1,7 +1,7 @@
 # embedjs-qdrant
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-redis/README.md
+++ b/databases/embedjs-redis/README.md
@@ -1,7 +1,7 @@
 # embedjs-redis
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/databases/embedjs-weaviate/README.md
+++ b/databases/embedjs-weaviate/README.md
@@ -1,7 +1,7 @@
 # embedjs-weaviate
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-confluence/README.md
+++ b/loaders/embedjs-loader-confluence/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-confluence
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-csv/README.md
+++ b/loaders/embedjs-loader-csv/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-csv
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-msoffice/README.md
+++ b/loaders/embedjs-loader-msoffice/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-msoffice
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-pdf/README.md
+++ b/loaders/embedjs-loader-pdf/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-pdf
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-sitemap/README.md
+++ b/loaders/embedjs-loader-sitemap/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-sitemap
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-web/README.md
+++ b/loaders/embedjs-loader-web/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-web
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/loaders/embedjs-loader-youtube/README.md
+++ b/loaders/embedjs-loader-youtube/README.md
@@ -1,7 +1,7 @@
 # embedjs-loader-youtube
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-anthropic/README.md
+++ b/models/embedjs-anthropic/README.md
@@ -1,7 +1,7 @@
 # embedjs-anthropic
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-cohere/README.md
+++ b/models/embedjs-cohere/README.md
@@ -1,7 +1,7 @@
 # embedjs-cohere
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-huggingface/README.md
+++ b/models/embedjs-huggingface/README.md
@@ -1,7 +1,7 @@
 # embedjs-huggingface
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-mistral/README.md
+++ b/models/embedjs-mistral/README.md
@@ -1,7 +1,7 @@
 # embedjs-mistral
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-ollama/README.md
+++ b/models/embedjs-ollama/README.md
@@ -1,7 +1,7 @@
 # embedjs-ollama
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-openai/README.md
+++ b/models/embedjs-openai/README.md
@@ -1,7 +1,7 @@
 # embedjs-openai
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 

--- a/models/embedjs-vertexai/README.md
+++ b/models/embedjs-vertexai/README.md
@@ -1,7 +1,7 @@
 # embedjs-vertexai
 
 <p>
-<a href="https://www.npmjs.com/package/@@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
+<a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="NPM Version" src="https://img.shields.io/npm/v/%40llm-tools/embedjs?style=for-the-badge"></a>
 <a href="https://www.npmjs.com/package/@llm-tools/embedjs"  target="_blank"><img alt="License" src="https://img.shields.io/npm/l/%40llm-tools%2Fembedjs?style=for-the-badge"></a>
 </p>
 


### PR DESCRIPTION
## Description

Noticed that all the READMEs linked to `https://www.npmjs.com/package/@@llm-tools/embedjs`. The double `@` lead to a 404 page. Also re-titled the README in the embedjs-astra package.

## Type of change

-   [x] Documentation update

