### PR TITLE
docs: fix PDF data source link in Overview

### DIFF
--- a/docs/components/data-sources/overview.mdx
+++ b/docs/components/data-sources/overview.mdx
@@ -6,7 +6,7 @@ EmbedJs comes with built-in support for various data sources.
 We handle the complexity of loading unstructured data from these data sources, allowing you to easily customize your app through a user-friendly interface.
 
 <CardGroup cols={4}>
-    <Card title="PDF file" href="/components/data-sources/pdf-file" />
+    <Card title="PDF file" href="/components/data-sources/pdf" />
     <Card title="CSV file" href="/components/data-sources/csv" />
     <Card title="JSON file" href="/components/data-sources/json" />
     <Card title="XML file" href="/components/data-sources/xml" />


### PR DESCRIPTION
[DataSources Pdf link](https://llm-tools.mintlify.app/components/data-sources/overview) currently points to a wrong url, this fixes the href reference

## Description

Old url  on overview page for DataSources points to `components/data-sources/pdf-file`   should be : `components/data-sources/pdf`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
-   [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] My changes generate no new tsc or eslint warnings
-   [x] I have ran tests that prove my fix is effective or that my feature works
-   [x] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes do not result in new npm audit errors
