### PR TITLE
fix: remove hardcoded trailing question mark from user query

### DIFF
--- a/core/embedjs-interfaces/src/interfaces/base-model.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-model.ts
@@ -70,7 +70,7 @@ export abstract class BaseModel {
                 else return new HumanMessage({ content: c.content });
             }),
         );
-        messages.push(new HumanMessage(`${userQuery}?`));
+        messages.push(new HumanMessage(userQuery));
         return messages;
     }
 


### PR DESCRIPTION
## Description

Took out the hardcoded question mark that was being added to user queries in `BaseModel` `prepare()` method. Not sure whether that was intentional, but it definitely feels off - especially when the query wasn't even a question to start with.

This was discovered independently and doesn't relate to any opened issues.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I verified that user queries are now always passed to the model exactly as-is.
No thorough testing required, since it's quite a simple and safe fix.

## Checklist:

-   [✅] My code follows the style guidelines of this project
-   [✅] I have performed a self-review of my own code
-   [❌] I have commented my code, particularly in hard-to-understand areas - **not applicable**
-   [❌] I have made corresponding changes to the documentation - **not applicable**
-   [✅] My changes generate no new tsc or eslint warnings
-   [✅] I have ran tests that prove my fix is effective or that my feature works
-   [❌] Any dependent changes have been merged and published in downstream modules - **not applicable**
-   [✅] I have checked my code and corrected any misspellings
-   [✅] My changes do not result in new npm audit errors
