### PR TITLE
fix: remove unnecessary slice for message history

### DIFF
--- a/core/embedjs-interfaces/src/interfaces/base-model.ts
+++ b/core/embedjs-interfaces/src/interfaces/base-model.ts
@@ -105,7 +105,7 @@ export abstract class BaseModel {
             conversation = { conversationId: 'default', entries: [] };
         }
 
-        const messages = await this.prepare(system, userQuery, supportingContext, conversation.entries.slice(0, -1));
+        const messages = await this.prepare(system, userQuery, supportingContext, conversation.entries);
         const uniqueSources = this.extractUniqueSources(supportingContext);
         const timestamp = new Date();
         const id = uuidv4();


### PR DESCRIPTION
## Description

When using this library, i notice that the LLM sometime answer to the previous message although it have been answered before. After debugging, i found out that the last message from the LLM before the new query is deleted, and after looking through the code, before sending the conversation history to the LLM, it call slice method to remove the last item on the history, and it remove the LLM last message.

This was discovered independently and doesn't relate to any opened issues.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I simply log the messages on the `prepare` method of the `BaseModel` class before returning, and do a simple query with this code.
```ts
import { RAGApplicationBuilder, SIMPLE_MODELS } from "@llm-tools/embedjs";
import { LibSqlStore } from "@llm-tools/embedjs-libsql";
import { OpenAiEmbeddings } from "@llm-tools/embedjs-openai";

const ragApplication = await new RAGApplicationBuilder()
	.setModel(SIMPLE_MODELS.OPENAI_GPT4_O)
	.setEmbeddingModel(new OpenAiEmbeddings())
	.setStore(new LibSqlStore({ path: "./db" }))
	.build();

await ragApplication.query("What is the net worth of Elon Musk today?");
await ragApplication.query("What about Jeff Bezos?");
```

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new tsc or eslint warnings
-   [x] I have ran tests that prove my fix is effective or that my feature works
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] I have checked my code and corrected any misspellings
-   [x] My changes do not result in new npm audit errors
