### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
     pull_request:
         branches: ['main']
 
+permissions:
+    contents: read
+
 env:
     NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/llm-tools/embedJs/security/code-scanning/2](https://github.com/llm-tools/embedJs/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. In this case, the workflow only needs read access to repository contents, so the `permissions` block should be set to `contents: read`. This change will ensure that the `GITHUB_TOKEN` used by the workflow has restricted access, mitigating potential security risks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
