### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/core/embedjs/src/store/memory-store.ts
+++ b/core/embedjs/src/store/memory-store.ts
@@ -8,7 +8,7 @@ export class MemoryStore implements BaseStore {
 
     async init(): Promise<void> {
         this.loaderList = {};
-        this.loaderCustomValues = {};
+        this.loaderCustomValues = Object.create(null);
         this.conversations = new Map();
         this.loaderCustomValuesMap = new Map();
     }
@@ -37,6 +37,9 @@ export class MemoryStore implements BaseStore {
     }
 
     async loaderCustomGet<T extends Record<string, unknown>>(key: string): Promise<T> {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+            throw new Error("Invalid key");
+        }
         const data = <T & { loaderId: string }>this.loaderCustomValues[key];
         delete data.loaderId;
         return data;


### PR DESCRIPTION
Potential fix for [https://github.com/llm-tools/embedJs/security/code-scanning/1](https://github.com/llm-tools/embedJs/security/code-scanning/1)

To prevent prototype pollution, we need to ensure that the `key` parameter cannot be a special property like `__proto__`, `constructor`, or `prototype`. This can be achieved by validating the `key` parameter before using it to access or modify the `loaderCustomValues` object. Alternatively, we can replace the plain object `loaderCustomValues` with a prototype-less object created using `Object.create(null)`.

The best approach here is to use a prototype-less object for `loaderCustomValues`, as it inherently prevents prototype pollution without requiring additional validation logic. This change will involve:
1. Modifying the initialization of `loaderCustomValues` in the `init` method to use `Object.create(null)`.
2. Ensuring that all operations on `loaderCustomValues` remain compatible with a prototype-less object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a prototype-less object for `loaderCustomValues` and validate disallowed keys in `loaderCustomGet` to prevent prototype pollution.
> 
> - **Security/Store**:
>   - Initialize `loaderCustomValues` with `Object.create(null)` in `core/embedjs/src/store/memory-store.ts`.
>   - Add key validation in `loaderCustomGet` to reject `__proto__`, `constructor`, and `prototype`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 173573ee3ab0b51c7ad9508463fa8f946610f4d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->